### PR TITLE
fix variable check

### DIFF
--- a/triggered.sh
+++ b/triggered.sh
@@ -62,8 +62,8 @@ done
 
 AARGS=
 
-[ -z "${AMODULES}" ] && AARGS="${AARGS} -M ${AMODULES}"
-[ -z "${ATAGS}" ] && AARGS="${AARGS} --tags ${ATAGS}"
+[ ! -z "${AMODULES}" ] && AARGS="${AARGS} -M ${AMODULES}"
+[ ! -z "${ATAGS}" ] && AARGS="${AARGS} --tags ${ATAGS}"
 
 # Execute Ansible.
 


### PR DESCRIPTION
I've finally said "!@#$ it!" to using ansible-pull and am now using this so thanks again for creating it!

In my tests it seems the check for AMODULES and ATAGS is backwards so here's a PR! 
